### PR TITLE
Fix to work with rust nightly 1.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ nightly = []
 benchmark = ["criterion", "time"]
 
 [dependencies.time]
-time = "*"
+version = "0.1.34"
 optional = true
 
 [dependencies.criterion]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 
-#![feature(core, alloc, box_syntax, optin_builtin_traits)]
+#![feature(heap_api, oom, alloc, box_syntax, optin_builtin_traits)]
 
 extern crate core;
 extern crate alloc;
@@ -213,7 +213,7 @@ impl<T> Drop for Buffer<T> {
         unsafe {
             deallocate(self.buffer as *mut u8,
                 self.allocated_size * mem::size_of::<T>(),
-                mem::min_align_of::<T>());
+                mem::align_of::<T>());
         }
     }
 }
@@ -292,7 +292,7 @@ unsafe fn allocate_buffer<T>(capacity: usize) -> *mut T {
     let size = adjusted_size.checked_mul(mem::size_of::<T>())
                 .expect("capacity overflow");
 
-    let ptr = allocate(size, mem::min_align_of::<T>()) as *mut T;
+    let ptr = allocate(size, mem::align_of::<T>()) as *mut T;
     if ptr.is_null() { ::alloc::oom() }
     ptr
 }


### PR DESCRIPTION
A few changes to suppress warnings and get it all to compile on 1.8.0 nightly. Still won't work on stable, due to the features and `oom()` instability.