### PR TITLE
Fix feature warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 #![feature(heap_api, oom, alloc, box_syntax, optin_builtin_traits)]
 
 extern crate core;


### PR DESCRIPTION
error: use of unstable library feature 'heap_api': the precise API and guarantees it provides may be tweaked slightly, especially to possibly take into account the types being stored to make room for a future tracing garbage collector (see issue #27700)
  --> /Users/joelr/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-spsc-queue-0.0.1/src/lib.rs:11:19
   |
11 | use alloc::heap::{allocate, deallocate};
   |                   ^^^^^^^^
   |
   = help: add #![feature(heap_api)] to the crate attributes to enable

error: use of unstable library feature 'heap_api': the precise API and guarantees it provides may be tweaked slightly, especially to possibly take into account the types being stored to make room for a future tracing garbage collector (see issue #27700)
  --> /Users/joelr/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-spsc-queue-0.0.1/src/lib.rs:11:29
   |
11 | use alloc::heap::{allocate, deallocate};
   |                             ^^^^^^^^^^
   |
   = help: add #![feature(heap_api)] to the crate attributes to enable

error: use of unstable library feature 'heap_api': the precise API and guarantees it provides may be tweaked slightly, especially to possibly take into account the types being stored to make room for a future tracing garbage collector (see issue #27700)
   --> /Users/joelr/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-spsc-queue-0.0.1/src/lib.rs:214:13
    |
214 |             deallocate(self.buffer as *mut u8,
    |             ^^^^^^^^^^
    |
    = help: add #![feature(heap_api)] to the crate attributes to enable

error: use of unstable library feature 'heap_api': the precise API and guarantees it provides may be tweaked slightly, especially to possibly take into account the types being stored to make room for a future tracing garbage collector (see issue #27700)
   --> /Users/joelr/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-spsc-queue-0.0.1/src/lib.rs:295:15
    |
295 |     let ptr = allocate(size, mem::min_align_of::<T>()) as *mut T;
    |               ^^^^^^^^
    |
    = help: add #![feature(heap_api)] to the crate attributes to enable

error: use of unstable library feature 'oom': not a scrutinized interface (see issue #27700)
   --> /Users/joelr/.cargo/registry/src/github.com-1ecc6299db9ec823/bounded-spsc-queue-0.0.1/src/lib.rs:296:24
    |
296 |     if ptr.is_null() { ::alloc::oom() }
    |                        ^^^^^^^^^^^^
    |
    = help: add #![feature(oom)] to the crate attributes to enable

error: aborting due to 5 previous errors

error: Could not compile `bounded-spsc-queue`.
