### PR TITLE
Fix Buffer's cache line padding on 32-bit targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,13 @@ use std::cell::Cell;
 use core::{mem, ptr};
 use core::mem::transmute;
 
+const CACHELINE_LEN: usize = 64;
 
 #[cfg(target_pointer_width = "32")]
-macro_rules! cacheline_pad { ($N:expr) => { 16 - $N } }
+macro_rules! cacheline_pad { ($N:expr) => { CACHELINE_LEN / 4 - $N } }
 
 #[cfg(target_pointer_width = "64")]
-macro_rules! cacheline_pad { ($N:expr) => { 8 - $N } }
+macro_rules! cacheline_pad { ($N:expr) => { CACHELINE_LEN / 8 - $N } }
 
 /* doesn't work yet: */
 //macro_rules! cacheline_pad {
@@ -563,6 +564,11 @@ mod tests {
 
     use super::*;
     use std::thread;
+
+    #[test]
+    fn test_buffer_size() {
+        assert_eq!(::std::mem::size_of::<Buffer<()>>(), 3 * CACHELINE_LEN);
+    }
 
     #[test]
     fn test_producer_push() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,21 +45,21 @@ pub struct Buffer<T> {
     /// The allocated size of the ring buffer, in terms of number of values (not physical memory).
     /// This will be the next power of two larger than `capacity`
     allocated_size: usize,
-    _padding1:      [u64;cacheline_pad!(3)],
+    _padding1:      [usize; cacheline_pad!(3)],
 
     /// Consumer cacheline:
 
     /// Index position of the current head
     head:           AtomicUsize,
     shadow_tail:    Cell<usize>,
-    _padding2:      [u64;cacheline_pad!(2)],
+    _padding2:      [usize; cacheline_pad!(2)],
 
     /// Producer cacheline:
 
     /// Index position of current tail
     tail:           AtomicUsize,
     shadow_head:    Cell<usize>,
-    _padding3:      [u64;cacheline_pad!(2)],
+    _padding3:      [usize; cacheline_pad!(2)],
 }
 
 unsafe impl<T: Sync> Sync for Buffer<T> { }


### PR DESCRIPTION
Please correct me if I'm wrong, but it looks to me that the cache line padding in Buffer is too large on 32-bit targets.

On 64-bit targets, the sizes are:

    buffer            8 bytes
    capacity          8 bytes
    allocated_size    8 bytes
    _padding1         40 bytes = 8 * (8 - 3)
                      --------
                      64 bytes

    head/tail         8 bytes
    shadow_tail/head  8 bytes
    _padding2/3       48 bytes = 8 * (8 - 2)
                      --------
                      64 bytes

On 32-bit however,

    buffer            4 bytes
    capacity          4 bytes
    allocated_size    4 bytes
    _padding1         104 bytes = 8 * (16 - 3)
                      --------
                      116 bytes

    head/tail         4 bytes
    shadow_tail/head  4 bytes
    _padding2/3       112 bytes = 8 * (16 - 2)
                      --------
                      120 bytes

Replacing the `u64` padding with `usize` padding makes the math work out, and seems like how `cacheline_pad!` was intended to work:

    buffer            4 bytes
    capacity          4 bytes
    allocated_size    4 bytes
    _padding1         52 bytes = 4 * (16 - 3)
                      --------
                      64 bytes

    head/tail         4 bytes
    shadow_tail/head  4 bytes
    _padding2/3       56 bytes = 4 * (16 - 2)
                      --------
                      64 bytes
