### PR TITLE
Assert size_of type parameter greater than zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,11 @@ impl<T> Drop for Buffer<T> {
 /// If the requested queue size is larger than available memory (e.g.
 /// `capacity.next_power_of_two() * size_of::<T>() > available memory` ), this function will abort
 /// with an OOM panic.
+///
+/// If the type parameter is a zero-size type.
 pub fn make<T>(capacity: usize) -> (Producer<T>, Consumer<T>) {
+
+    assert!(0 < std::mem::size_of::<T>(), "zero-size types are not supported");
 
     let ptr = unsafe { allocate_buffer(capacity) };
 


### PR DESCRIPTION
Partial fix for: https://github.com/polyfractal/bounded-spsc-queue/issues/15

I couldn't figure out how to make this a compile-time error. It may be possible to do something with [CTFE](https://github.com/rust-lang/rfcs/issues/322) when that is more fleshed out.