### PR TITLE
Remove stable allocator_api feature attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(allocator_api)]
-
 extern crate core;
 
 use core::alloc::Layout;


### PR DESCRIPTION
Feature allocator_api is stable now, so stable rust can compile the crate without this attribute.

Fixes #9.