### PR TITLE
remove allocator API requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(allocator_api)]
-
 extern crate core;
 
 use core::alloc::Layout;


### PR DESCRIPTION
I figured I'd have to adapt the code a bit to remove that, but right
now as of 2020 just by removing the feature the code compile just
fine with the stable compiler:

My environment:
  $ rustup default
  stable-x86_64-unknown-linux-gnu (default)

I intend to use this as a building block for my crate, Scipio
(https://crates.io/crates/scipio) but I'd like to enforce stable
there.